### PR TITLE
Fix Client import from primp

### DIFF
--- a/fast_flights/primp.py
+++ b/fast_flights/primp.py
@@ -1,4 +1,4 @@
-from primp.primp import RClient as Client  # type: ignore
+from primp import as Client  # type: ignore
 
 
 class Response: ...


### PR DESCRIPTION
Fixing:

'''
/usr/local/lib/python3.11/dist-packages/fast_flights/core.py in fetch(params)
     12 def fetch(params: dict) -> Response:
     13     client = Client(impersonate="chrome_126", verify=False)
---> 14     res = client.get("https://www.google.com/travel/flights", params=params)
     15     assert res.status_code == 200, f"{res.status_code} Result: {res.text_markdown}"
     16     return res

AttributeError: 'builtins.RClient' object has no attribute 'get'
'''