### PR TITLE
Possibility of using local Playwright

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -1,0 +1,31 @@
+# Local Playwright
+
+In case the Playwright serverless functions are down or you prefer not to use them, you can run the Playwright server locally and request against that.
+
+1. Install this package with the dependencies needed for Playwright:
+
+```bash
+pip install fast-flights[local]
+```
+
+2. Install the Playwright browser:
+
+```bash
+python -m playwright install chromium # or `python -m playwright install` if you want to install all browsers
+```
+
+3. Now you can use the `fetch_mode="local"` parameter in `get_flights`:
+
+```python
+get_flights(
+    ...,
+    fetch_mode="local"  # common/fallback/force-fallback/local
+)
+
+# ...or:
+
+get_fights_from_filter(
+    filter,
+    mode="local"  # common/fallback/force-fallback/local
+)
+```

--- a/fast_flights/core.py
+++ b/fast_flights/core.py
@@ -20,7 +20,7 @@ def get_flights_from_filter(
     filter: TFSData,
     currency: str = "",
     *,
-    mode: Literal["common", "fallback", "force-fallback"] = "common",
+    mode: Literal["common", "fallback", "force-fallback", "local"] = "common",
 ) -> Result:
     data = filter.as_b64()
 
@@ -39,6 +39,11 @@ def get_flights_from_filter(
                 res = fallback_playwright_fetch(params)
             else:
                 raise e
+
+    elif mode == "local":
+        from .local_playwright import local_playwright_fetch
+
+        res = local_playwright_fetch(params)
 
     else:
         res = fallback_playwright_fetch(params)

--- a/fast_flights/core.py
+++ b/fast_flights/core.py
@@ -62,7 +62,7 @@ def get_flights(
     trip: Literal["round-trip", "one-way", "multi-city"],
     passengers: Passengers,
     seat: Literal["economy", "premium-economy", "business", "first"],
-    fetch_mode: Literal["common", "fallback", "force-fallback"] = "common",
+    fetch_mode: Literal["common", "fallback", "force-fallback", "local"] = "common",
     max_stops: Optional[int] = None,
 ) -> Result:
     return get_flights_from_filter(

--- a/fast_flights/local_playwright.py
+++ b/fast_flights/local_playwright.py
@@ -1,0 +1,29 @@
+from typing import Any
+import asyncio
+from playwright.async_api import async_playwright
+
+async def fetch_with_playwright(url: str) -> str:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto(url)
+        if page.url.startswith("https://consent.google.com"):
+            await page.click('text="Accept all"')
+        locator = page.locator('.eQ35Ce')
+        await locator.wait_for()
+        body = await page.evaluate(
+            "() => document.querySelector('[role=\"main\"]').innerHTML"
+        )
+        await browser.close()
+    return body
+
+def local_playwright_fetch(params: dict) -> Any:
+    url = "https://www.google.com/travel/flights?" + "&".join(f"{k}={v}" for k, v in params.items())
+    body = asyncio.run(fetch_with_playwright(url))
+
+    class DummyResponse:
+        status_code = 200
+        text = body
+        text_markdown = body
+
+    return DummyResponse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dependencies = [
   "selectolax"
 ]
 
+[project.optional-dependencies]
+local = [
+    "playwright"
+]
+
 [project.urls]
 "Source" = "https://github.com/AWeirdDev/flights"
 "Issues" = "https://github.com/AWeirdDev/flights/issues"


### PR DESCRIPTION
I am getting a 401 error when using the fallback method lately, most possibly because I made too many requests to the serverless Playwright!

So, I implemented a way of using good old local Playwright optionally.

The most important changes include updates to the documentation, core functions, and the addition of a new module to handle local Playwright fetching, as well as the inclusion of Playwright as an optional dependency.

* **Documentation Update**:
  - [`docs/local.md`](diffhunk://#diff-0420d82944b077a49c61c063fe4d0d8341bea629a9e11057f69e88ce8343fe23R1-R31): Added instructions for running Playwright locally, including installation steps and usage examples.

* **Core Function Updates**:
  - [`fast_flights/core.py`](diffhunk://#diff-90c7698428b6cbbabc3fb5fa4ab4489598702d053ec27dd8cb44240e4d2e7758L23-R23): Added "local" as a valid mode for `get_flights` and `get_flights_from_filter` functions, and implemented the logic to handle the "local" mode by calling a new function from the `local_playwright` module. [[1]](diffhunk://#diff-90c7698428b6cbbabc3fb5fa4ab4489598702d053ec27dd8cb44240e4d2e7758L23-R23) [[2]](diffhunk://#diff-90c7698428b6cbbabc3fb5fa4ab4489598702d053ec27dd8cb44240e4d2e7758R43-R47) [[3]](diffhunk://#diff-90c7698428b6cbbabc3fb5fa4ab4489598702d053ec27dd8cb44240e4d2e7758L60-R65)

* **New Module**:
  - [`fast_flights/local_playwright.py`](diffhunk://#diff-11096ae6ad6c1e986e9042150b3f305921fff32805460f08876e24d2287ade2dR1-R29): Created a new module to fetch flight data using Playwright locally, including an asynchronous function to interact with the browser and a synchronous function to fetch data based on provided parameters. It also sidesteps the cookie modal with the most amazing method of clicking on 'Accept all'.

* **Dependencies**:
  - [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27-R31): Added an optional dependency for Playwright, allowing users to install it when they need to run Playwright locally. This _should_ play nicely with `pip`, and attempting to install it locally with the `[local]` thing at the end worked, but I have no idea if it will work when the package is on PyPI (although, again, it should).
  
Thank you for this amazing project, it is really useful :)