### PR TITLE
Add price type option (best/cheapest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ result: Result = get_flights(
     seat="economy",
     passengers=Passengers(adults=2, children=1, infants_in_seat=0, infants_on_lap=0),
     fetch_mode="fallback",
+    price_type="cheapest",
 )
 
 print(result)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ result: Result = get_flights(
     trip="one-way",# (2)!
     seat="economy",# (3)!
     passengers=Passengers(adults=2, children=1, infants_in_seat=0, infants_on_lap=0),# (4)!
-    fetch_mode="fallback",#(5)!
+    fetch_mode="fallback",# (5)!
+    price_type="cheapest",# (6)!
 )
 
 print(result)
@@ -37,6 +38,7 @@ print(result)
 3. :material-seat: Money-spending time! This specifies the seat type, which is `economy`, `premium-economy`, `business`, or `first`.
 4. :fontawesome-solid-people-line: Nice interface, eh? This specifies the number of a specific passenger type.
 5. :fontawesome-solid-person-falling: Sometimes, the data is built on demand on the client-side, while the core of `fast-flights` is built around scrapers from the ground up. We support fallbacks that run Playwright serverless functions to fetch for us instead. You could either specify `common` (default), `fallback` (recommended), or `force-fallback` (100% serverless Playwright). You do not need to install Playwright in order for this to work.
+6. :material-cash-multiple: This specifies the price type. Choose `"best"` (default) for official airline prices, or `"cheapest"` for the lowest prices from travel agencies. The `"cheapest"` option searches across multiple booking sites to find you the best deal!
 
 ## How it's made
 

--- a/example.py
+++ b/example.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument('--type', type=str, default="economy", help="Fare class (economy, premium-economy, business or first)")
     parser.add_argument('--max_stops', type=int, help="Maximum number of stops (optional, [0|1|2])")
     parser.add_argument('--fetch_mode', type=str, default="common", help="Fetch mode: common, fallback, force-fallback, local, bright-data")
+    parser.add_argument('--price_type', type=str, default="best", help="Price type: best (official airline prices) or cheapest (travel agency prices)")
 
 
     args = parser.parse_args()
@@ -68,7 +69,8 @@ def main():
 
     # Get flights with the filter
     result = get_flights_from_filter(filter,
-                                     mode=args.fetch_mode
+                                     mode=args.fetch_mode,
+                                     price_type=args.price_type
                                      )
 
     try:

--- a/fast_flights/core.py
+++ b/fast_flights/core.py
@@ -28,6 +28,7 @@ def get_flights_from_filter(
     *,
     mode: Literal["common", "fallback", "force-fallback", "local", "bright-data"] = "common",
     data_source: Literal['js'] = ...,
+    price_type: Literal["best", "cheapest"] = "best",
 ) -> Union[DecodedResult, None]: ...
 
 @overload
@@ -37,6 +38,7 @@ def get_flights_from_filter(
     *,
     mode: Literal["common", "fallback", "force-fallback", "local", "bright-data"] = "common",
     data_source: Literal['html'],
+    price_type: Literal["best", "cheapest"] = "best",
 ) -> Result: ...
 
 def get_flights_from_filter(
@@ -45,13 +47,16 @@ def get_flights_from_filter(
     *,
     mode: Literal["common", "fallback", "force-fallback", "local", "bright-data"] = "common",
     data_source: DataSource = 'html',
+    price_type: Literal["best", "cheapest"] = "best",
 ) -> Union[Result, DecodedResult, None]:
     data = filter.as_b64()
+
+    tfu_value = "EgQIABABIgA" if price_type == "best" else "EgoIABAAGAAgAigLIgA"
 
     params = {
         "tfs": data.decode("utf-8"),
         "hl": "en",
-        "tfu": "EgQIABABIgA",
+        "tfu": tfu_value,
         "curr": currency,
     }
 
@@ -79,7 +84,7 @@ def get_flights_from_filter(
         return parse_response(res, data_source)
     except RuntimeError as e:
         if mode == "fallback":
-            return get_flights_from_filter(filter, mode="force-fallback")
+            return get_flights_from_filter(filter, mode="force-fallback", price_type=price_type)
         raise e
 
 
@@ -92,6 +97,7 @@ def get_flights(
     fetch_mode: Literal["common", "fallback", "force-fallback", "local", "bright-data"] = "common",
     max_stops: Optional[int] = None,
     data_source: DataSource = 'html',
+    price_type: Literal["best", "cheapest"] = "best",
 ) -> Union[Result, DecodedResult, None]:
     return get_flights_from_filter(
         TFSData.from_interface(
@@ -103,6 +109,7 @@ def get_flights(
         ),
         mode=fetch_mode,
         data_source=data_source,
+        price_type=price_type,
     )
 
 


### PR DESCRIPTION
Thank you for this super cool project!
Google Flights officially offers two pricing options when searching: "Best" and "Cheapest". Currently, we could only fetch "Best" prices, so I added the price_type option to support fetching both "Best" and "Cheapest" prices.
<img width="1107" height="554" alt="best_and_cheapest" src="https://github.com/user-attachments/assets/6d784a07-174b-4a84-b588-7cafae18062a" />
