### PR TITLE
Add flight_number field to Flight schema

### DIFF
--- a/fast_flights/core.py
+++ b/fast_flights/core.py
@@ -269,6 +269,10 @@ def parse_response(
             # Get prices
             price = safe(item.css_first(".YMlIz.FpEdX")).text() or "0"
 
+            # Get flight number (from the flight details section)
+            # Flight numbers appear in spans like "F9 1230" or "UA 820"
+            flight_number = safe(item.css_first("span.Xsgmwe")).text(strip=True) or None
+
             # Stops formatting
             try:
                 stops_fmt = 0 if stops == "Nonstop" else int(stops.split(" ", 1)[0])
@@ -286,6 +290,7 @@ def parse_response(
                     "stops": stops_fmt,
                     "delay": delay,
                     "price": price.replace(",", ""),
+                    "flight_number": flight_number,
                 }
             )
 

--- a/fast_flights/schema.py
+++ b/fast_flights/schema.py
@@ -21,3 +21,4 @@ class Flight:
     stops: int
     delay: Optional[str]
     price: str
+    flight_number: Optional[str] = None


### PR DESCRIPTION
## Summary
- Add `flight_number: Optional[str] = None` field to the `Flight` dataclass in schema.py
- Add extraction logic in core.py to attempt to parse flight numbers from HTML

## Context
The JS data source (decoder.py) already includes flight numbers in its `Flight` class, but the HTML-based `Result.Flight` class in schema.py was missing this field. This PR adds the field for schema consistency.

## Notes
- The HTML parser extraction uses `span.Xsgmwe` selector, but Google Flights doesn't expose flight numbers in the collapsed list view HTML
- Flight numbers are only reliably available via the JS data source (`data_source='js'`)
- This change maintains backwards compatibility as `flight_number` defaults to `None`

## Test plan
- [ ] Verified schema.py change compiles
- [ ] Verified core.py change doesn't break existing parsing
- [ ] Tested with `data_source='js'` to confirm flight numbers are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flight results now include flight number information for enhanced flight identification and tracking.

* **Bug Fixes**
  * Enhanced error handling for stops parsing with automatic fallback when data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->