### PR TITLE
feat: add Google Hotels scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ query = create_query(
 res = get_flights(query)
 ```
 
+## Hotels
+
+Search Google Hotels and get structured results — no new dependencies required. Uses the same `primp` + `selectolax` stack as `get_flights()`.
+
+```python
+from fast_flights import get_hotels
+
+result = get_hotels(
+    location="Lisbon Portugal",
+    checkin="2026-06-03",
+    checkout="2026-06-06",
+    adults=2,
+)
+for hotel in result.hotels:
+    print(f"{hotel.name} — ${hotel.price_per_night}/night ({hotel.stars}★ {hotel.rating}/5)")
+```
+
+Each `Hotel` object contains: `name`, `price_per_night`, `total_price`, `currency`, `stars`, `rating`, `reviews`, `source`, and `amenities`. Results are sorted by price ascending.
+
 ## Integrations
 If you'd like, you can use integrations.
 

--- a/fast_flights/__init__.py
+++ b/fast_flights/__init__.py
@@ -8,6 +8,8 @@ from .querying import (
     create_query as create_filter,  # alias
 )
 from .fetcher import get_flights, fetch_flights_html
+from .hotels import get_hotels
+from .hotels_schema import Hotel, HotelResult
 
 __all__ = [
     "FlightQuery",
@@ -18,4 +20,7 @@ __all__ = [
     "get_flights",
     "fetch_flights_html",
     "integrations",
+    "get_hotels",
+    "Hotel",
+    "HotelResult",
 ]

--- a/fast_flights/hotels.py
+++ b/fast_flights/hotels.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
 import re
+from datetime import date
 from typing import List
+from urllib.parse import quote_plus
 
 from .hotels_schema import Hotel, HotelResult
 
 
-# Noise strings that indicate a regex match is garbage (CSS/JS artifacts)
+# Currency code → symbol mapping for price regex matching
+_CURRENCY_SYMBOLS = {
+    "USD": r"\$",
+    "EUR": r"€",
+    "GBP": r"£",
+    "JPY": r"¥",
+    "CAD": r"CA\$",
+    "AUD": r"A\$",
+}
+
+# Noise strings that indicate a regex match is a CSS/JS artifact, not a hotel
 _NOISE = frozenset(["{", "Loading", "Sponsored", "font-smooth", "VfPpkd", "$"])
 
 
@@ -25,9 +37,14 @@ def get_hotels(
         checkout: Check-out date in YYYY-MM-DD format.
         adults: Number of adult guests (default: 2).
         currency: Currency code for prices (default: "USD").
+            Supported: USD, EUR, GBP, JPY, CAD, AUD.
 
     Returns:
         HotelResult containing a list of Hotel objects sorted by price.
+
+    Raises:
+        ValueError: If checkout is not after checkin.
+        RuntimeError: If the Google Hotels request fails.
 
     Example::
 
@@ -45,10 +62,17 @@ def get_hotels(
     import primp
     from selectolax.parser import HTMLParser
 
-    query = location.replace(" ", "+")
+    # Validate dates
+    checkin_date = date.fromisoformat(checkin)
+    checkout_date = date.fromisoformat(checkout)
+    nights = (checkout_date - checkin_date).days
+    if nights <= 0:
+        raise ValueError(f"checkout ({checkout}) must be after checkin ({checkin})")
+
+    # Build URL with proper encoding for special characters (e.g. "São Paulo")
     url = (
         f"https://www.google.com/travel/hotels"
-        f"?q=hotels+in+{query}"
+        f"?q=hotels+in+{quote_plus(location)}"
         f"&checkin={checkin}"
         f"&checkout={checkout}"
         f"&adults={adults}"
@@ -58,16 +82,18 @@ def get_hotels(
 
     client = primp.Client(impersonate="chrome_131", verify=False)
     resp = client.get(url)
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Google Hotels request failed with status {resp.status_code}"
+        )
+
     tree = HTMLParser(resp.text)
 
-    # Calculate number of nights for total price
-    from datetime import date
-    checkin_date = date.fromisoformat(checkin)
-    checkout_date = date.fromisoformat(checkout)
-    nights = (checkout_date - checkin_date).days
-
-    _pattern = re.compile(
-        r"^(.+?)\$(\d+)([\w\.\s]+?)(\d+\.\d+)/5\(([0-9\.]+[K]?)\)·(\d)-star hotel(.*)$"
+    # Use dynamic currency symbol so non-USD results are matched correctly
+    symbol = _CURRENCY_SYMBOLS.get(currency, re.escape(currency))
+    pattern = re.compile(
+        rf"^(.+?){symbol}(\d+)([\w\.\s]+?)(\d+\.\d+)/5\(([0-9\.]+[K]?)\)·(\d)-star hotel(.*)$"
     )
 
     hotels: List[Hotel] = []
@@ -75,7 +101,7 @@ def get_hotels(
 
     for div in tree.css("div"):
         text = div.text(strip=True)
-        m = _pattern.match(text)
+        m = pattern.match(text)
         if not m:
             continue
 

--- a/fast_flights/hotels.py
+++ b/fast_flights/hotels.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+from typing import List
+
+from .hotels_schema import Hotel, HotelResult
+
+
+# Noise strings that indicate a regex match is garbage (CSS/JS artifacts)
+_NOISE = frozenset(["{", "Loading", "Sponsored", "font-smooth", "VfPpkd", "$"])
+
+
+def get_hotels(
+    location: str,
+    checkin: str,
+    checkout: str,
+    adults: int = 2,
+    currency: str = "USD",
+) -> HotelResult:
+    """Search Google Hotels and return structured results.
+
+    Args:
+        location: Hotel search location (e.g. "Lisbon Portugal").
+        checkin: Check-in date in YYYY-MM-DD format.
+        checkout: Check-out date in YYYY-MM-DD format.
+        adults: Number of adult guests (default: 2).
+        currency: Currency code for prices (default: "USD").
+
+    Returns:
+        HotelResult containing a list of Hotel objects sorted by price.
+
+    Example::
+
+        from fast_flights import get_hotels
+
+        result = get_hotels(
+            location="Lisbon Portugal",
+            checkin="2026-06-03",
+            checkout="2026-06-06",
+            adults=2,
+        )
+        for hotel in result.hotels:
+            print(f"{hotel.name} — ${hotel.price_per_night}/night ({hotel.stars}★ {hotel.rating}/5)")
+    """
+    import primp
+    from selectolax.parser import HTMLParser
+
+    query = location.replace(" ", "+")
+    url = (
+        f"https://www.google.com/travel/hotels"
+        f"?q=hotels+in+{query}"
+        f"&checkin={checkin}"
+        f"&checkout={checkout}"
+        f"&adults={adults}"
+        f"&hl=en"
+        f"&curr={currency}"
+    )
+
+    client = primp.Client(impersonate="chrome_131", verify=False)
+    resp = client.get(url)
+    tree = HTMLParser(resp.text)
+
+    # Calculate number of nights for total price
+    from datetime import date
+    checkin_date = date.fromisoformat(checkin)
+    checkout_date = date.fromisoformat(checkout)
+    nights = (checkout_date - checkin_date).days
+
+    _pattern = re.compile(
+        r"^(.+?)\$(\d+)([\w\.\s]+?)(\d+\.\d+)/5\(([0-9\.]+[K]?)\)·(\d)-star hotel(.*)$"
+    )
+
+    hotels: List[Hotel] = []
+    seen: set = set()
+
+    for div in tree.css("div"):
+        text = div.text(strip=True)
+        m = _pattern.match(text)
+        if not m:
+            continue
+
+        name, price_str, source, rating_str, reviews, stars_str, rest = m.groups()
+        name = name.strip()
+
+        if name in seen or not (3 < len(name) < 55):
+            continue
+        if any(noise in name for noise in _NOISE):
+            continue
+
+        seen.add(name)
+        amenities = [
+            a.strip()
+            for a in re.split(r"·|\n", rest)
+            if a.strip() and len(a.strip()) < 40
+        ]
+
+        price_per_night = int(price_str)
+        hotels.append(
+            Hotel(
+                name=name,
+                price_per_night=price_per_night,
+                total_price=price_per_night * nights,
+                currency=currency,
+                stars=int(stars_str),
+                rating=float(rating_str),
+                reviews=reviews.strip(),
+                source=source.strip(),
+                amenities=amenities[:3],
+            )
+        )
+
+    hotels.sort(key=lambda h: h.price_per_night)
+    return HotelResult(hotels=hotels)

--- a/fast_flights/hotels_schema.py
+++ b/fast_flights/hotels_schema.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Hotel:
+    name: str
+    price_per_night: int
+    total_price: int
+    currency: str
+    stars: int
+    rating: float
+    reviews: str
+    source: str
+    amenities: List[str]
+
+
+@dataclass
+class HotelResult:
+    hotels: List[Hotel]


### PR DESCRIPTION
## Summary

Adds `get_hotels()` — a Google Hotels scraper built on the same `primp` + `selectolax` stack already used by `get_flights()`.

No new dependencies required. Works by fetching the Google Hotels page with browser impersonation and parsing hotel cards directly from the server-rendered HTML.

## Usage

\`\`\`python
from fast_flights import get_hotels

result = get_hotels(
    location="Lisbon Portugal",
    checkin="2026-06-03",
    checkout="2026-06-06",
    adults=2,
)
for hotel in result.hotels:
    print(f"{hotel.name} — \${hotel.price_per_night}/night ({hotel.stars}★ {hotel.rating}/5)")
\`\`\`

## Returns

- \`HotelResult\` containing a sorted list of \`Hotel\` objects
- Each \`Hotel\` has: \`name\`, \`price_per_night\`, \`total_price\`, \`currency\`, \`stars\`, \`rating\`, \`reviews\`, \`source\`, \`amenities\`

## New files
- \`fast_flights/hotels.py\` — \`get_hotels()\` implementation
- \`fast_flights/hotels_schema.py\` — \`Hotel\` and \`HotelResult\` dataclasses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hotel search to find accommodations by location, check-in/check-out dates, guest count; results show nightly and total prices, currency, ratings, reviews, stars, amenities, and booking sources, deduplicated and sorted by price.

* **Documentation**
  * README updated with hotel search API usage, example requests, and field descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->