### PR TITLE
feat: Add optional URL return to get_flights and fetch_flights_html functions

### DIFF
--- a/fast_flights/fetcher.py
+++ b/fast_flights/fetcher.py
@@ -1,4 +1,4 @@
-from typing import overload
+from typing import Literal, overload
 
 from primp import Client
 
@@ -10,7 +10,13 @@ URL = "https://www.google.com/travel/flights"
 
 
 @overload
-def get_flights(q: str, /, *, proxy: str | None = None) -> MetaList:
+def get_flights(
+    q: str,
+    /,
+    *,
+    proxy: str | None = None,
+    return_url: Literal[False] = False,
+) -> MetaList:
     """Get flights using a str query.
 
     Examples:
@@ -19,7 +25,28 @@ def get_flights(q: str, /, *, proxy: str | None = None) -> MetaList:
 
 
 @overload
-def get_flights(q: Query, /, *, proxy: str | None = None) -> MetaList:
+def get_flights(
+    q: str,
+    /,
+    *,
+    proxy: str | None = None,
+    return_url: Literal[True],
+) -> tuple[MetaList, str]:
+    """Get flights using a str query, returning both flights and URL.
+
+    Examples:
+    - *Flights from TPE to MYJ on 2025-12-22 one way economy class*
+    """
+
+
+@overload
+def get_flights(
+    q: Query,
+    /,
+    *,
+    proxy: str | None = None,
+    return_url: Literal[False] = False,
+) -> MetaList:
     """Get flights using a structured query.
 
     Example:
@@ -44,21 +71,65 @@ def get_flights(q: Query, /, *, proxy: str | None = None) -> MetaList:
     """
 
 
+@overload
+def get_flights(
+    q: Query,
+    /,
+    *,
+    proxy: str | None = None,
+    return_url: Literal[True],
+) -> tuple[MetaList, str]:
+    """Get flights using a structured query, returning both flights and URL.
+
+    Example:
+    ```python
+    get_flights(
+        query(
+            flights=[
+                FlightQuery(
+                    date="2025-12-22",
+                    from_airport="TPE",
+                    to_airport="MYJ",
+                )
+            ],
+            seat="economy",
+            trip="one-way",
+            passengers=Passengers(adults=1),
+            language="en-US",
+            currency="",
+        ),
+        return_url=True
+    )
+    ```
+    """
+
+
 def get_flights(
     q: Query | str,
     /,
     *,
     proxy: str | None = None,
     integration: Integration | None = None,
-) -> MetaList:
+    return_url: bool = False,
+) -> MetaList | tuple[MetaList, str]:
     """Get flights.
 
     Args:
         q: The query.
         proxy (str, optional): Proxy.
+        return_url (bool, optional): If True, returns a tuple of (MetaList, url).
+            If False (default), returns only MetaList for backward compatibility.
+    
+    Returns:
+        MetaList if return_url is False (default), or
+        tuple of (MetaList, url) if return_url is True.
     """
-    html = fetch_flights_html(q, proxy=proxy, integration=integration)
-    return parse(html)
+    html, url = fetch_flights_html(q, proxy=proxy, integration=integration)
+    flights = parse(html)
+    
+    if return_url:
+        return flights, url
+    return flights
 
 
 def fetch_flights_html(
@@ -67,12 +138,16 @@ def fetch_flights_html(
     *,
     proxy: str | None = None,
     integration: Integration | None = None,
-) -> str:
-    """Fetch flights and get the **HTML**.
+) -> tuple[str, str]:
+    """Fetch flights and get the **HTML** and **URL**.
 
     Args:
         q: The query.
         proxy (str, optional): Proxy.
+    
+    Returns:
+        A tuple of (html, url) where html is the response text
+        and url is the final URL of the request.
     """
     if integration is None:
         client = Client(
@@ -90,7 +165,8 @@ def fetch_flights_html(
             params = {"q": q}
 
         res = client.get(URL, params=params)
-        return res.text
+        return res.text, str(res.url)
 
     else:
-        return integration.fetch_html(q)
+        html = integration.fetch_html(q)
+        return html, URL


### PR DESCRIPTION
## Summary
Enhances the `get_flights()` and `fetch_flights_html()` functions to optionally return the final request URL alongside the flight data, enabling better debugging and URL sharing capabilities.

## Changes
- Added `return_url` parameter to `get_flights()` function (default: `False` for backward compatibility)
- Modified `fetch_flights_html()` to return a tuple of `(html, url)` instead of just `html`
- Added proper type hints with `Literal` types for overloaded function signatures
- Updated function signatures to support both return types:
  - `return_url=False` (default): Returns `MetaList` only
  - `return_url=True`: Returns `tuple[MetaList, str]` with flights and URL

## Benefits
- **Backward Compatible**: Existing code continues to work without changes
- **Better Debugging**: Developers can now access the actual Google Flights URL used for the query
- **URL Sharing**: Users can share or inspect the exact URL being queried
- **Type Safety**: Proper overloads ensure type checkers understand both return patterns

## Example Usage
```python
# Default behavior (backward compatible)
flights = get_flights(query)

# New behavior with URL
flights, url = get_flights(query, return_url=True)
print(f"Query URL: {url}")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parameter to retrieve flight search source URL alongside flight results, enabling users to access the original query URL when needed.
  * Default behavior remains unchanged, maintaining full backward compatibility with existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->