### PR TITLE
Parse Google Flights shopping XHR responses

### DIFF
--- a/fast_flights/__init__.py
+++ b/fast_flights/__init__.py
@@ -8,6 +8,7 @@ from .querying import (
     create_query as create_filter,  # alias
 )
 from .fetcher import get_flights, fetch_flights_html
+from .fetch_result import FetchResult
 
 __all__ = [
     "FlightQuery",
@@ -17,5 +18,6 @@ __all__ = [
     "create_filter",
     "get_flights",
     "fetch_flights_html",
+    "FetchResult",
     "integrations",
 ]

--- a/fast_flights/fetch_result.py
+++ b/fast_flights/fetch_result.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FetchResult:
+    """Result returned by integrations that capture both HTML and XHR data."""
+
+    html: str = ""
+    xhr_bodies: list[str | bytes] = field(default_factory=list)
+    url: str | None = None

--- a/fast_flights/fetcher.py
+++ b/fast_flights/fetcher.py
@@ -2,6 +2,7 @@ from typing import overload
 
 from primp import Client
 
+from .fetch_result import FetchResult
 from .integrations.base import Integration
 from .parser import MetaList, parse
 from .querying import Query
@@ -57,8 +58,8 @@ def get_flights(
         q: The query.
         proxy (str, optional): Proxy.
     """
-    html = fetch_flights_html(q, proxy=proxy, integration=integration)
-    return parse(html)
+    fetched = fetch_flights_html(q, proxy=proxy, integration=integration)
+    return parse(fetched)
 
 
 def fetch_flights_html(
@@ -67,7 +68,7 @@ def fetch_flights_html(
     *,
     proxy: str | None = None,
     integration: Integration | None = None,
-) -> str:
+) -> str | FetchResult:
     """Fetch flights and get the **HTML**.
 
     Args:

--- a/fast_flights/integrations/__init__.py
+++ b/fast_flights/integrations/__init__.py
@@ -1,4 +1,5 @@
 from .base import Integration
 from .bright_data import BrightData
+from .playwright import Playwright
 
-__all__ = ["Integration", "BrightData"]
+__all__ = ["Integration", "BrightData", "Playwright"]

--- a/fast_flights/integrations/base.py
+++ b/fast_flights/integrations/base.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC
 
+from ..fetch_result import FetchResult
 from ..querying import Query
 
 try:
@@ -15,7 +16,7 @@ except ModuleNotFoundError:
 class Integration(ABC):
     """Represents an integration."""
 
-    def fetch_html(self, q: Query | str, /) -> str:
+    def fetch_html(self, q: Query | str, /) -> str | FetchResult:
         """Fetch the flights page HTML from a query.
 
         Args:

--- a/fast_flights/integrations/playwright.py
+++ b/fast_flights/integrations/playwright.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..fetch_result import FetchResult
+from ..querying import Query
+from .base import Integration
+
+GOOGLE_FLIGHTS_URL = "https://www.google.com/travel/flights"
+XHR_MARKER = "FlightsFrontendService/GetShoppingResults"
+
+
+class Playwright(Integration):
+    """Local Chromium integration that captures Google Flights shopping XHRs."""
+
+    def fetch_html(self, q: Query | str, /) -> FetchResult:
+        from playwright.sync_api import sync_playwright
+
+        url = q.url() if isinstance(q, Query) else GOOGLE_FLIGHTS_URL + "?q=" + q
+        response_objects: list[Any] = []
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(
+                user_agent=(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/145.0.0.0 Safari/537.36"
+                ),
+                locale="en-US",
+                viewport={"width": 1280, "height": 900},
+            )
+            page = context.new_page()
+            page.add_init_script("""
+                Object.defineProperty(navigator, 'webdriver', {get: () => undefined});
+                window.chrome = {runtime: {}};
+                Object.defineProperty(navigator, 'plugins', {get: () => [1, 2, 3, 4, 5]});
+                Object.defineProperty(navigator, 'languages', {get: () => ['en-US', 'en']});
+            """)
+
+            def on_response(response: Any) -> None:
+                if XHR_MARKER in response.url:
+                    response_objects.append(response)
+
+            page.on("response", on_response)
+            try:
+                page.goto(
+                    GOOGLE_FLIGHTS_URL,
+                    timeout=25_000,
+                    wait_until="domcontentloaded",
+                )
+                page.wait_for_timeout(1_000)
+            except Exception:
+                pass
+
+            page.goto(url, timeout=25_000, wait_until="domcontentloaded")
+            try:
+                page.wait_for_load_state("networkidle", timeout=12_000)
+            except Exception:
+                pass
+            page.wait_for_timeout(2_000)
+
+            xhr_bodies: list[bytes] = []
+            for response in response_objects:
+                try:
+                    xhr_bodies.append(response.body())
+                except Exception:
+                    pass
+
+            html = page.content()
+            browser.close()
+
+        return FetchResult(html=html, xhr_bodies=xhr_bodies, url=url)

--- a/fast_flights/model.py
+++ b/fast_flights/model.py
@@ -18,6 +18,7 @@ class Alliance:
 class JsMetadata:
     airlines: list[Airline]
     alliances: list[Alliance]
+    diagnostics: dict[str, object] | None = None
 
 
 @dataclass

--- a/fast_flights/parser.py
+++ b/fast_flights/parser.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import json
+from typing import Any, Iterable
 
 from selectolax.lexbor import LexborHTMLParser
 
+from .fetch_result import FetchResult
 from .model import (
     Airline,
     Airport,
@@ -18,95 +22,412 @@ class MetaList(list[Flights]):
     """Searched flights list, with metadata attached."""
 
     metadata: JsMetadata
+    diagnostics: dict[str, object]
 
 
-def parse(html: str) -> MetaList:
-    parser = LexborHTMLParser(html)
+ERROR_RESPONSE = "type.googleapis.com/travel.frontend.flights.ErrorResponse"
+
+
+def parse(source: str | bytes | FetchResult) -> MetaList:
+    """Parse Google Flights HTML or captured XHR writeback responses."""
+
+    if isinstance(source, FetchResult):
+        remembered_empty: MetaList | None = None
+        for body in source.xhr_bodies:
+            xhr_result = parse_xhr_body(body)
+            if xhr_result is None:
+                continue
+            if xhr_result:
+                return xhr_result
+            if remembered_empty is None:
+                remembered_empty = xhr_result
+
+        html_result = _parse_html(source.html)
+        if html_result or _status(html_result) != "missing_script_ds1":
+            return html_result
+        return remembered_empty if remembered_empty is not None else html_result
+
+    if isinstance(source, bytes):
+        source = source.decode("utf-8", errors="replace")
+    return _parse_html(source or "")
+
+
+def _parse_html(html: str) -> MetaList:
+    parser = LexborHTMLParser(html or "")
 
     # find js
     script = parser.css_first(r"script.ds\:1")
+    if script is None:
+        return _empty("missing_script_ds1", source="html")
     return parse_js(script.text())
 
 
 # Data discovery by @kftang, huge shout out!
-def parse_js(js: str):
-    data = js.split("data:", 1)[1].rsplit(",", 1)[0]
-    print(data)
+def parse_js(js: str) -> MetaList:
+    try:
+        payload = json.loads(_extract_data_expr(js))
+    except Exception as exc:
+        return _empty("malformed_script_data", source="script.ds:1", detail=str(exc))
+    return _parse_payload(payload, source="script.ds:1")
 
-    payload = json.loads(data)
+
+def parse_xhr_body(body: str | bytes) -> MetaList | None:
+    """Parse a Google writeback body, returning None for unrelated XHRs."""
+
+    try:
+        frames = list(_google_json_frames(body))
+    except Exception as exc:
+        return _empty("malformed_xhr_body", source="xhr", detail=str(exc))
+
+    saw_wrb = False
+    remembered_empty: MetaList | None = None
+    for frame in frames:
+        if _has_wrb_frame(frame):
+            saw_wrb = True
+        for payload in _wrb_payloads(frame):
+            try:
+                decoded = json.loads(payload) if isinstance(payload, str) else payload
+            except Exception as exc:
+                remembered_empty = _empty(
+                    "malformed_wrb_payload", source="xhr", detail=str(exc)
+                )
+                continue
+
+            if _contains_error_response(decoded):
+                return _empty("google_error_response", source="xhr")
+
+            parsed = _parse_payload(decoded, source="xhr")
+            if parsed:
+                return parsed
+            remembered_empty = parsed
+
+    if remembered_empty is not None:
+        return remembered_empty
+    if saw_wrb:
+        return _empty("no_parseable_xhr", source="xhr")
+    return None
+
+
+def _has_wrb_frame(frame: Any) -> bool:
+    if not isinstance(frame, list):
+        return False
+    if frame and frame[0] == "wrb.fr":
+        return True
+    return any(_has_wrb_frame(item) for item in frame)
+
+
+def _parse_payload(payload: Any, *, source: str) -> MetaList:
+    if _contains_error_response(payload):
+        return _empty("google_error_response", source=source)
+    if not isinstance(payload, list):
+        return _empty("malformed_flight_payload", source=source)
 
     alliances = []
     airlines = []
 
-    (alliances_data, airlines_data) = (
-        payload[7][1][0],
-        payload[7][1][1],
-    )
+    try:
+        alliances_data = payload[7][1][0] or []
+        airlines_data = payload[7][1][1] or []
+    except (IndexError, TypeError):
+        alliances_data, airlines_data = [], []
 
-    for code, name in alliances_data:
-        alliances.append(Alliance(code=code, name=name))
+    for row in alliances_data:
+        if isinstance(row, list) and len(row) >= 2:
+            alliances.append(Alliance(code=str(row[0]), name=str(row[1])))
 
-    for code, name in airlines_data:
-        airlines.append(Airline(code=code, name=name))
+    for row in airlines_data:
+        if isinstance(row, list) and len(row) >= 2:
+            airlines.append(Airline(code=str(row[0]), name=str(row[1])))
 
     meta = JsMetadata(alliances=alliances, airlines=airlines)
 
     flights = MetaList()
-    if payload[3][0] is None:
+    flights.metadata = meta
+
+    rows = list(_itinerary_rows(payload))
+    if not rows:
+        _set_diagnostics(flights, {"status": "empty_flight_payload", "source": source})
         return flights
 
-    for k in payload[3][0]:
-        flight = k[0]
-        price = k[1][0][1]
+    parse_errors = 0
+    seen: set[tuple[Any, ...]] = set()
+    for row in rows:
+        try:
+            flight = _flight_from_row(row)
+        except Exception:
+            parse_errors += 1
+            continue
 
-        typ = flight[0]
-        airlines = flight[1]
+        key = _flight_key(flight)
+        if key in seen:
+            continue
+        seen.add(key)
+        flights.append(flight)
 
-        sg_flights = []
-
-        # multiple flights!
-        for single_flight in flight[2]:
-            from_airport = Airport(code=single_flight[3], name=single_flight[4])
-            to_airport = Airport(code=single_flight[6], name=single_flight[5])
-            departure_time = single_flight[8]
-            departure_date = single_flight[20]
-            departure = SimpleDatetime(date=departure_date, time=departure_time)
-
-            arrival_time = single_flight[10]
-            arrival_date = single_flight[21]
-            arrival = SimpleDatetime(date=arrival_date, time=arrival_time)
-
-            plane_type = single_flight[17]
-
-            duration = single_flight[11]
-
-            sg_flights.append(
-                SingleFlight(
-                    from_airport=from_airport,
-                    to_airport=to_airport,
-                    departure=departure,
-                    arrival=arrival,
-                    duration=duration,
-                    plane_type=plane_type,
-                )
-            )
-
-        # some additional data
-        extras = flight[22]
-        carbon_emission = extras[7]
-        typical_carbon_emission = extras[8]
-
-        flights.append(
-            Flights(
-                type=typ,
-                price=price,
-                airlines=airlines,
-                flights=sg_flights,
-                carbon=CarbonEmission(
-                    typical_on_route=typical_carbon_emission, emission=carbon_emission
-                ),
-            )
-        )
-
-    flights.metadata = meta
+    _set_diagnostics(
+        flights,
+        {
+            "status": "ok" if flights else "malformed_flight_payload",
+            "source": source,
+            "parse_errors": parse_errors,
+        },
+    )
     return flights
+
+
+def _itinerary_rows(payload: list[Any]) -> Iterable[list[Any]]:
+    for index in (2, 3):
+        yield from _rows_from_block(_get(payload, index), depth=0)
+
+
+def _rows_from_block(block: Any, *, depth: int) -> Iterable[list[Any]]:
+    if depth > 4 or not isinstance(block, list):
+        return
+    if _is_itinerary_row(block):
+        yield block
+        return
+    for item in block:
+        if _is_itinerary_row(item):
+            yield item
+        elif isinstance(item, list):
+            yield from _rows_from_block(item, depth=depth + 1)
+
+
+def _is_itinerary_row(value: Any) -> bool:
+    if not isinstance(value, list) or len(value) < 2:
+        return False
+    flight = value[0]
+    return (
+        isinstance(flight, list)
+        and len(flight) > 22
+        and isinstance(_get(flight, 2), list)
+    )
+
+
+def _flight_from_row(row: list[Any]) -> Flights:
+    flight = row[0]
+    sg_flights = [
+        _single_flight_from_row(single_flight)
+        for single_flight in (_get(flight, 2) or [])
+        if isinstance(single_flight, list)
+    ]
+    extras = _get(flight, 22) or []
+
+    return Flights(
+        type=str(_get(flight, 0) or ""),
+        price=_price_from_node(_get(row, 1)) or 0,
+        airlines=[str(airline) for airline in (_get(flight, 1) or []) if airline],
+        flights=sg_flights,
+        carbon=CarbonEmission(
+            typical_on_route=_as_int(_get(extras, 8)) or 0,
+            emission=_as_int(_get(extras, 7)) or 0,
+        )
+    )
+
+
+def _single_flight_from_row(single_flight: list[Any]) -> SingleFlight:
+    from_code = str(_get(single_flight, 3) or "")
+    to_code = str(_get(single_flight, 6) or "")
+    return SingleFlight(
+        from_airport=Airport(
+            code=from_code,
+            name=str(_get(single_flight, 4) or from_code),
+        ),
+        to_airport=Airport(
+            code=to_code,
+            name=str(_get(single_flight, 5) or to_code),
+        ),
+        departure=SimpleDatetime(
+            date=_date_tuple(_get(single_flight, 20)),
+            time=_time_tuple(_get(single_flight, 8)),
+        ),
+        arrival=SimpleDatetime(
+            date=_date_tuple(_get(single_flight, 21)),
+            time=_time_tuple(_get(single_flight, 10)),
+        ),
+        duration=_as_int(_get(single_flight, 11)) or 0,
+        plane_type=str(_get(single_flight, 17) or ""),
+    )
+
+
+def _google_json_frames(body: str | bytes) -> Iterable[Any]:
+    text = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else body
+    text = text or ""
+    if text.startswith(")]}'"):
+        text = text.split("\n", 1)[1] if "\n" in text else ""
+    lines = [line for line in text.splitlines() if line.strip()]
+
+    yielded = False
+    for index, line in enumerate(lines):
+        if line.strip().isdigit() and index + 1 < len(lines):
+            yielded = True
+            yield json.loads(lines[index + 1])
+
+    if yielded:
+        return
+
+    stripped = "\n".join(lines).strip()
+    if stripped:
+        yield json.loads(stripped)
+
+
+def _wrb_payloads(frame: Any) -> Iterable[Any]:
+    if not isinstance(frame, list):
+        return
+    if frame and frame[0] == "wrb.fr":
+        if len(frame) > 2 and frame[2] is not None:
+            yield frame[2]
+        for item in frame[3:]:
+            if item is not None:
+                yield item
+        return
+    for item in frame:
+        yield from _wrb_payloads(item)
+
+
+def _extract_data_expr(js: str) -> str:
+    marker = "data:"
+    start = js.find(marker)
+    if start < 0:
+        raise ValueError("script.ds:1 has no data field")
+    pos = start + len(marker)
+    while pos < len(js) and js[pos].isspace():
+        pos += 1
+    if pos >= len(js) or js[pos] not in "[{":
+        return js[start + len(marker) :].rsplit(",", 1)[0]
+
+    stack = ["]" if js[pos] == "[" else "}"]
+    in_string = False
+    quote = ""
+    escape = False
+    for end in range(pos + 1, len(js)):
+        char = js[end]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                in_string = False
+            continue
+
+        if char in {'"', "'"}:
+            in_string = True
+            quote = char
+        elif char in "[{":
+            stack.append("]" if char == "[" else "}")
+        elif char in "]}":
+            if not stack or char != stack[-1]:
+                raise ValueError("unbalanced data payload")
+            stack.pop()
+            if not stack:
+                return js[pos : end + 1]
+
+    raise ValueError("unterminated data payload")
+
+
+def _contains_error_response(value: Any) -> bool:
+    if isinstance(value, str):
+        return ERROR_RESPONSE in value
+    if isinstance(value, list):
+        return any(_contains_error_response(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_error_response(item) for item in value.values())
+    return False
+
+
+def _empty(status: str, *, source: str, detail: str | None = None) -> MetaList:
+    result = MetaList()
+    diagnostic: dict[str, object] = {"status": status, "source": source}
+    if detail:
+        diagnostic["detail"] = detail
+    result.metadata = JsMetadata(alliances=[], airlines=[], diagnostics=diagnostic)
+    result.diagnostics = diagnostic
+    return result
+
+
+def _set_diagnostics(result: MetaList, diagnostics: dict[str, object]) -> None:
+    result.diagnostics = diagnostics
+    result.metadata.diagnostics = diagnostics
+
+
+def _status(result: MetaList) -> str | None:
+    diagnostics = getattr(result, "diagnostics", None)
+    if isinstance(diagnostics, dict):
+        status = diagnostics.get("status")
+        return str(status) if status is not None else None
+    meta_diagnostics = getattr(getattr(result, "metadata", None), "diagnostics", None)
+    if isinstance(meta_diagnostics, dict):
+        status = meta_diagnostics.get("status")
+        return str(status) if status is not None else None
+    return None
+
+
+def _flight_key(flight: Flights) -> tuple[Any, ...]:
+    legs = tuple(
+        (
+            leg.from_airport.code,
+            leg.to_airport.code,
+            leg.departure.date,
+            leg.departure.time,
+            leg.arrival.date,
+            leg.arrival.time,
+        )
+        for leg in flight.flights
+    )
+    return (flight.price, tuple(flight.airlines), legs)
+
+
+def _price_from_node(value: Any) -> int | None:
+    direct = _as_int(value)
+    if direct is not None:
+        return direct
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, list) and len(item) > 1:
+                nested = _as_int(item[1])
+                if nested is not None:
+                    return nested
+        for item in value:
+            nested = _price_from_node(item)
+            if nested is not None:
+                return nested
+    return None
+
+
+def _date_tuple(value: Any) -> tuple[int, int, int]:
+    parts = _int_tuple(value)
+    return (parts + (0, 0, 0))[:3]
+
+
+def _time_tuple(value: Any) -> tuple[int, int]:
+    parts = _int_tuple(value)
+    return (parts + (0, 0))[:2]
+
+
+def _int_tuple(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    ints: list[int] = []
+    for item in value:
+        parsed = _as_int(item)
+        if parsed is not None:
+            ints.append(parsed)
+    return tuple(ints)
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _get(value: Any, index: int, default: Any = None) -> Any:
+    try:
+        return value[index]
+    except (TypeError, IndexError):
+        return default

--- a/tests/test_parser_xhr.py
+++ b/tests/test_parser_xhr.py
@@ -1,0 +1,152 @@
+import json
+
+import pytest
+
+from fast_flights import FetchResult
+from fast_flights.parser import parse
+
+
+def _flight_row(price=380, airline="American", code="AA"):
+    single = [None] * 25
+    single[3] = "RDU"
+    single[4] = "Raleigh-Durham International Airport"
+    single[5] = "Adolfo Suarez Madrid-Barajas Airport"
+    single[6] = "MAD"
+    single[8] = [7, 15]
+    single[10] = [20, 45]
+    single[11] = 450
+    single[17] = "Boeing 777"
+    single[20] = [2026, 8, 1]
+    single[21] = [2026, 8, 1]
+
+    flight = [None] * 25
+    flight[0] = code
+    flight[1] = [airline]
+    flight[2] = [single]
+    flight[22] = [None, None, None, None, None, None, None, 542000, 498000]
+    return [flight, [[None, price]]]
+
+
+def _payload(rows):
+    data = [None] * 8
+    data[3] = [rows]
+    data[7] = [
+        None,
+        [
+            [["ONEWORLD", "Oneworld"]],
+            [["AA", "American"]],
+        ],
+    ]
+    return data
+
+
+def _script_html(data):
+    return (
+        '<html><script class="ds:1">'
+        f"AF_initDataCallback({{key: 'ds:1', data: {json.dumps(data)}, sideChannel: {{}}}});"
+        "</script></html>"
+    )
+
+
+def _wrb_body(payload):
+    frame = [["wrb.fr", None, json.dumps(payload)]]
+    return ")]}'\n\n123\n" + json.dumps(frame)
+
+
+def _error_body():
+    return (
+        ")]}'\n\n269\n"
+        '[["wrb.fr",null,null,null,null,[3,null,'
+        '[["type.googleapis.com/travel.frontend.flights.ErrorResponse",[]]]]]]'
+    )
+
+
+def _wrb_frame_body(frame):
+    return ")]}'\n\n123\n" + json.dumps(frame)
+
+
+def test_script_ds1_fixture_still_parses():
+    result = parse(_script_html(_payload([_flight_row()])))
+
+    assert len(result) == 1
+    assert result[0].price == 380
+    assert result[0].airlines == ["American"]
+    assert result[0].flights[0].from_airport.code == "RDU"
+    assert result.metadata.airlines[0].code == "AA"
+
+
+def test_missing_script_returns_empty_with_diagnostic_metadata():
+    result = parse("<html><body>No flights here</body></html>")
+
+    assert result == []
+    assert result.metadata.diagnostics["status"] == "missing_script_ds1"
+
+
+def test_error_response_wrb_returns_empty_with_diagnostic_metadata():
+    result = parse(FetchResult(html="", xhr_bodies=[_error_body()]))
+
+    assert result == []
+    assert result.metadata.diagnostics["status"] == "google_error_response"
+    assert result.metadata.diagnostics["source"] == "xhr"
+
+
+@pytest.mark.parametrize(
+    ("body", "status"),
+    [
+        ("not json", "malformed_xhr_body"),
+        (_wrb_frame_body([["wrb.fr", None, "{bad"]]), "malformed_wrb_payload"),
+        (_wrb_body(_payload([])), "empty_flight_payload"),
+        (_wrb_frame_body([["wrb.fr", None, None]]), "no_parseable_xhr"),
+    ],
+)
+def test_empty_xhr_results_include_diagnostic_metadata(body, status):
+    result = parse(FetchResult(html="", xhr_bodies=[body]))
+
+    assert result == []
+    assert result.metadata.diagnostics["status"] == status
+    assert result.metadata.diagnostics["source"] == "xhr"
+
+
+def test_captured_wrb_payload_parses_existing_models():
+    result = parse(
+        FetchResult(
+            html="<html></html>",
+            xhr_bodies=[_wrb_body(_payload([_flight_row(426)]))],
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].price == 426
+    assert result[0].carbon.emission == 542000
+    assert result[0].flights[0].arrival.date == (2026, 8, 1)
+
+
+def test_get_flights_uses_integration_xhr_payload():
+    import fast_flights as ff
+
+    class FakeQuery:
+        pass
+
+    class FakeIntegration:
+        def fetch_html(self, q):
+            return FetchResult(
+                html="<html></html>",
+                xhr_bodies=[_wrb_body(_payload([_flight_row(512)]))],
+            )
+
+    result = ff.get_flights(FakeQuery(), integration=FakeIntegration())
+
+    assert len(result) == 1
+    assert result[0].price == 512
+
+
+def test_later_valid_xhr_wins_after_earlier_error_xhr():
+    result = parse(
+        FetchResult(
+            html="<html></html>",
+            xhr_bodies=[_error_body(), _wrb_body(_payload([_flight_row(614)]))],
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].price == 614


### PR DESCRIPTION
Google Flights does not always expose parseable itinerary data in the initial
`script.ds:1` HTML anymore. Browser-backed integrations can still see the
shopping result payload in `FlightsFrontendService/GetShoppingResults` XHR
responses.

This adds support for integrations returning both the final HTML and captured
XHR bodies, then parses `wrb.fr` writeback payloads before falling back to the
existing `script.ds:1` parser.

The existing HTML/string parser path is kept for backwards compatibility.

Main changes:
- add a `FetchResult` container for `html`, `xhr_bodies`, and `url`
- parse captured `wrb.fr` XHR payloads from Google Flights shopping results
- keep legacy `script.ds:1` parsing as fallback
- add diagnostic metadata for missing script data, Google error responses, and
  malformed/empty payloads
- update the local Playwright integration to capture `GetShoppingResults`
  responses

Tests added for:
- existing `script.ds:1` fixtures
- missing script data
- Google `ErrorResponse` XHRs
- captured `wrb.fr` payloads
- integrations returning `FetchResult`
- later valid XHR payloads after an earlier error response

Tested with:

```bash
python -m pytest tests -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser-based flight search integration with automatic capture of flight data responses.
  * Enhanced parser to handle captured XHR responses alongside HTML content.
  * Improved diagnostic reporting for parsing failures and missing data.

* **Bug Fixes**
  * Strengthened parsing resilience with better handling of malformed payloads and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->