### PR TITLE
fix: bypass Google cookie consent wall breaking all searches

### DIFF
--- a/fast_flights/fetcher.py
+++ b/fast_flights/fetcher.py
@@ -83,6 +83,11 @@ def fetch_flights_html(
             cookie_store=True,
         )
 
+        # Pre-set the SOCS cookie to bypass Google's cookie consent page.
+        # Without this, Google returns a "Before you continue" consent wall
+        # instead of flight results, causing all searches to fail.
+        client.set_cookies(URL, {"SOCS": "CAISNQgDEitib3FfaWRlbnRpdHlmcm9udGVuZHVpc2VydmVyXzIwMjMwODE1LjA3X3AxGgJlbiACGgYIgJnPpwY"})
+
         if isinstance(q, Query):
             params = q.params()
 

--- a/fast_flights/parser.py
+++ b/fast_flights/parser.py
@@ -31,7 +31,6 @@ def parse(html: str) -> MetaList:
 # Data discovery by @kftang, huge shout out!
 def parse_js(js: str):
     data = js.split("data:", 1)[1].rsplit(",", 1)[0]
-    print(data)
 
     payload = json.loads(data)
 


### PR DESCRIPTION
## Summary

- **Pre-set the `SOCS` cookie** on the `primp` Client before making the request to Google Flights. Google now shows a "Before you continue" cookie consent page before serving any content, causing all flight searches to fail with "No flights found".
- **Remove stray `print(data)` debug statement** in `parser.py` that dumped the raw JSON payload to stdout on every search.

## Problem

Google changed their consent flow — all requests to `google.com/travel/flights` now return a cookie consent wall instead of flight results. The `primp` client receives HTML containing "Before you continue to Google" instead of the expected flight data page. This breaks **every search** regardless of route, date, or configuration.

## Fix

Setting the `SOCS` cookie tells Google that cookie consent has already been given. The consent wall is skipped and the actual flight results page is returned.

```python
client.set_cookies(URL, {"SOCS": "CAISNQgD..."})
```

## Testing

Before fix:
```
$ flight-search JFK LAX --date 2026-05-20
Error: No flights found. Check your airports and dates.
```

After fix:
```
$ flight-search JFK LAX --date 2026-05-20
Found 30 flights
  American | $235 | 7:04 -> 12:33 | 2 leg(s)
  Delta    | $246 | 8:00 -> 11:10 | 1 leg(s)
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flight search result retrieval reliability and consistency by enhancing request handling for more dependable performance.

* **Chores**
  * Removed debug code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->